### PR TITLE
Enable WiFi power save mode

### DIFF
--- a/POLVERINE_HOMEASSISTANT_DEMO/src/connectivity/wifi_connect.c
+++ b/POLVERINE_HOMEASSISTANT_DEMO/src/connectivity/wifi_connect.c
@@ -239,6 +239,12 @@ void wifi_start(void)
     ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
     ESP_LOGI(TAG, "Starting WiFi...");
     ESP_ERROR_CHECK(esp_wifi_start());
+    
+    // Enable WiFi power save mode for better light sleep compatibility
+    ESP_LOGI(TAG, "Enabling WiFi power save mode...");
+    ESP_ERROR_CHECK(esp_wifi_set_ps(WIFI_PS_MIN_MODEM));
+    ESP_LOGI(TAG, "WiFi power save mode enabled");
+    
     ESP_LOGI(TAG, "WiFi started successfully");
 }
 

--- a/POLVERINE_HOMEASSISTANT_DEMO/src/main.c
+++ b/POLVERINE_HOMEASSISTANT_DEMO/src/main.c
@@ -54,7 +54,7 @@ static const char *TAG = "power_management";
         esp_pm_config_t pm_config = {
             .max_freq_mhz = 160,
             .min_freq_mhz = 80,
-            .light_sleep_enable = false  // Disable light sleep to improve WiFi stability
+            .light_sleep_enable = true  // Enable light sleep with WiFi power save
         };
 
         esp_err_t err = esp_pm_configure(&pm_config);


### PR DESCRIPTION
Using the power safe mode here now for some time. As I did not run into WiFi stability issues, I wanted to share my change. Not sure exactly, why it was disabled in the first place.